### PR TITLE
Fixed multiple gcc v7.2.0 warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,4 +158,4 @@ List of ISO 8583-like specifications used by Card Payment System associations:
   
 A huge list of different acquirers national and domestic payment services which also used ISO 8583 messages are not in this list.  
 Specifications available for the members of these associations. They are confidential usually but could be found in the web if you know which specification to search.  
-The services around payments industry like iso8583.info providing details about the messages content with data parsing and test hosts.
+The services around payments industry like [iso8583.info](http://iso8583.info) providing details about the messages content with data parsing and test hosts.

--- a/lib/dl_iso8583.c
+++ b/lib/dl_iso8583.c
@@ -285,8 +285,6 @@ void DL_ISO8583_MSG_Dump ( FILE                     *iOutFile,
 	{
 		if ( NULL != iMsg->field[i].ptr ) /* present */
 		{
-			DL_ISO8583_FIELD_DEF *fieldDef = DL_ISO8583_GetFieldDef(i,iHandler);
-
 			fprintf(iOutFile,"[%03d] ",
 					(int)i);
 			fprintf(iOutFile,"%s%s",iMsg->field[i].ptr,tmpEOL);

--- a/lib/dl_iso8583_common.c
+++ b/lib/dl_iso8583_common.c
@@ -61,7 +61,7 @@ DL_ERR _DL_ISO8583_MSG_AllocField ( DL_UINT16        iField,
 	}
 	else /* dynamic mode */
 	{
-		err = DL_MEM_malloc(iSize+1,&tmpPtr);
+		err = DL_MEM_malloc(iSize+1,(void**)&tmpPtr);
 
 		if ( !err )
 		{

--- a/lib/dl_iso8583_fields.c
+++ b/lib/dl_iso8583_fields.c
@@ -447,9 +447,10 @@ DL_ERR _pack_iso_BITMAP ( DL_UINT16                    iField,
 	DL_ERR     err         = kDL_ERR_NONE;
 	DL_UINT8  *tmpPtr      = *ioPtr;
 	DL_UINT16  curFieldIdx = iField;
+	unsigned i;
 
 	/* for each possible bitmap segment */
-	for ( unsigned i=0 ; i<((kDL_ISO8583_MAX_FIELD_IDX-iField+1)+63)/64 ; i++ )
+	for ( i=0 ; i<((kDL_ISO8583_MAX_FIELD_IDX-iField+1)+63)/64 ; i++ )
 	{
 		DL_UINT32 ms=0,
 				  ls=0;

--- a/lib/dl_iso8583_fields.c
+++ b/lib/dl_iso8583_fields.c
@@ -244,7 +244,7 @@ DL_ERR _unpack_iso_ASCHEX ( DL_UINT16                    iField,
 	DL_UINT8  *tmpDataPtr = NULL;
 
 	/* variable length handling */
-	err = VarLen_Get(&tmpPtr,iFieldDefPtr->varLen,iFieldDefPtr->len,&size);
+	err = VarLen_Get((const DL_UINT8 **)&tmpPtr,iFieldDefPtr->varLen,iFieldDefPtr->len,&size);
 
 	/* allocate field */
 	if ( !err )
@@ -339,7 +339,7 @@ DL_ERR _unpack_iso_ASCII ( DL_UINT16                    iField,
 	DL_UINT8  *tmpDataPtr = NULL;
 
 	/* variable length handling */
-	err = VarLen_Get(&tmpPtr,iFieldDefPtr->varLen,iFieldDefPtr->len,&size);
+	err = VarLen_Get((const DL_UINT8 **)&tmpPtr,iFieldDefPtr->varLen,iFieldDefPtr->len,&size);
 
 	/* allocate field */
 	if ( !err )
@@ -417,7 +417,7 @@ DL_ERR _unpack_iso_BINARY ( DL_UINT16                    iField,
 	DL_UINT8  *tmpDataPtr = NULL;
 
 	/* variable length handling */
-	err = VarLen_Get(&tmpPtr,iFieldDefPtr->varLen,iFieldDefPtr->len,&size);
+	err = VarLen_Get((const DL_UINT8 **)&tmpPtr,iFieldDefPtr->varLen,iFieldDefPtr->len,&size);
 
 	/* allocate field */
 	if ( !err )
@@ -447,10 +447,9 @@ DL_ERR _pack_iso_BITMAP ( DL_UINT16                    iField,
 	DL_ERR     err         = kDL_ERR_NONE;
 	DL_UINT8  *tmpPtr      = *ioPtr;
 	DL_UINT16  curFieldIdx = iField;
-	int        i;
 
 	/* for each possible bitmap segment */
-	for ( i=0 ; i<((kDL_ISO8583_MAX_FIELD_IDX-iField+1)+63)/64 ; i++ )
+	for ( unsigned i=0 ; i<((kDL_ISO8583_MAX_FIELD_IDX-iField+1)+63)/64 ; i++ )
 	{
 		DL_UINT32 ms=0,
 				  ls=0;

--- a/lib/dl_str.c
+++ b/lib/dl_str.c
@@ -45,7 +45,7 @@ static void unescape_string ( DL_CHAR  iEscCh,
 
 DL_CHAR *DL_STR_GetEnv ( const DL_CHAR *iEnvStr )
 {
-    return DL_STR_SafeStr(getenv(iEnvStr));
+    return DL_STR_SafeStr(getenv((const char*)iEnvStr));
 }
 
 /******************************************************************************/
@@ -55,7 +55,7 @@ int DL_STR_StrLen ( const DL_CHAR *iStr )
 	int len = 0;
 
 	if ( iStr != NULL )
-		len = (int)strlen(iStr);
+		len = (int)strlen((const char*)iStr);
 
 	return len;
 }
@@ -171,7 +171,7 @@ void DL_STR_StrCpy ( DL_CHAR       *ioToPtr,
 	else if ( DL_STR_StrLen(iFromPtr) <= iMaxChars ) /* within length */
 	{
 		/* simple string copy */
-		(void)strcpy(ioToPtr,iFromPtr);
+		(void)strcpy((char*)ioToPtr,(const char*)iFromPtr);
 	}
 	else /* too long - so chop */
 	{
@@ -206,7 +206,7 @@ DL_ERR DL_STR_StrNDup ( const DL_CHAR  *iStr,
 	{
 		err = kDL_ERR_OTHER;
 	}
-	else if ( err = DL_MEM_malloc(iMaxChars+1,oStr) )
+	else if ( (err = DL_MEM_malloc(iMaxChars+1,(void**)oStr)) )
 	{
 		/* error - do nothing */
 	}
@@ -240,7 +240,7 @@ DL_ERR DL_STR_StrCat ( const DL_CHAR  *iStr1,
 	str2len = DL_STR_StrLen(iStr2);
 
 	/* allocate memory for combined string */
-	err = DL_MEM_malloc(str1len+str2len+1,oStr);
+	err = DL_MEM_malloc(str1len+str2len+1,(void**)oStr);
 
 	if ( !err )
 	{
@@ -385,7 +385,7 @@ int DL_STR_Validate ( const DL_CHAR *iStr,
 		{
 			/* validate contents */
 			for ( i=0 ; (i<(int)DL_STR_StrLen(iStr)) && ok ; i++ )
-				if ( DL_STR_StrChr(iValidChars,(int)(iStr[i])) == NULL )
+				if ( DL_STR_StrChr((const char*)iValidChars,(int)(iStr[i])) == NULL )
 					ok = 0;
 		}
 	}
@@ -404,7 +404,7 @@ int DL_STR_Contains ( const DL_CHAR *iStr,
 	{
 		while ( *iStr != kDL_ASCII_NULL )
 		{
-			if ( DL_STR_StrChr(iContains,(int)(*iStr)) != NULL )
+			if ( DL_STR_StrChr((const char *)iContains,(int)(*iStr)) != NULL )
 			{
 				ret = 1;
 				break;
@@ -430,7 +430,7 @@ DL_ERR DL_STR_EncapsulateStr ( const DL_CHAR  *iStr,
 	*oStr = NULL;
 
 	/* allocate working buffer (NB (Length(iStr)*2)+2+1 ) */
-	err = DL_MEM_malloc((DL_STR_StrLen(iStr)*2)+2+1,&bufPtr);
+	err = DL_MEM_malloc((DL_STR_StrLen(iStr)*2)+2+1,(void**)&bufPtr);
 
 	if ( !err )
 	{
@@ -579,7 +579,7 @@ DL_CHAR *DL_STR_ReadToBuffer ( const DL_CHAR *iStr,
 	int      charsRead = 0;
 
 	while ( (kDL_ASCII_NULL != *readPtr) &&
-		    (DL_STR_StrChr(iValidChars,(int)(*readPtr)) != NULL) &&
+		    (DL_STR_StrChr((const char*)iValidChars,(int)(*readPtr)) != NULL) &&
 		    (charsRead < iBufferSize) )
 	{
 		*oBuffer = *readPtr;

--- a/lib/dl_str.h
+++ b/lib/dl_str.h
@@ -46,7 +46,7 @@ extern DL_CHAR kDL_STR_EmptyStr[1];
 
 /* returns an empty string if the pointer is NULL */
 #define DL_STR_SafeStr(str)\
- ((str)==NULL?kDL_STR_EmptyStr:(str))
+ ( (str)==NULL ? (DL_CHAR*)kDL_STR_EmptyStr : (DL_CHAR*)(str))
 
 /* accepts a pointer to a numeric - outputs safe values (ie 0 if NULL) */
 #define DL_STR_SafeNum(a)\

--- a/lib/dl_time.c
+++ b/lib/dl_time.c
@@ -689,7 +689,7 @@ static int timestamp_to_struct ( const char *iTimestampStr,
 	DL_MEM_memset(oData,0,sizeof(DL_TIME));
 
 	/* check 'timestamp' format (high-level) */
-	ok = DL_STR_Validate(iTimestampStr,kDL_TIME_TIMESTAMP_LEN,kDL_TIME_TIMESTAMP_LEN,"0123456789");
+	ok = DL_STR_Validate((const DL_CHAR *)iTimestampStr,kDL_TIME_TIMESTAMP_LEN,kDL_TIME_TIMESTAMP_LEN,(const DL_CHAR *)"0123456789");
 
 	/* check that date/time string is within the required range */
     if ( ok && ((DL_STR_StrCmp((const DL_CHAR *)iTimestampStr,(const DL_CHAR *)kTIMESTAMP_MIN_VALUE,0) == -1) ||

--- a/lib/dl_time.c
+++ b/lib/dl_time.c
@@ -692,8 +692,8 @@ static int timestamp_to_struct ( const char *iTimestampStr,
 	ok = DL_STR_Validate(iTimestampStr,kDL_TIME_TIMESTAMP_LEN,kDL_TIME_TIMESTAMP_LEN,"0123456789");
 
 	/* check that date/time string is within the required range */
-    if ( ok && ((DL_STR_StrCmp(iTimestampStr,kTIMESTAMP_MIN_VALUE,0) == -1) ||
-                (DL_STR_StrCmp(iTimestampStr,kTIMESTAMP_MAX_VALUE,0) ==  1)) )
+    if ( ok && ((DL_STR_StrCmp((const DL_CHAR *)iTimestampStr,(const DL_CHAR *)kTIMESTAMP_MIN_VALUE,0) == -1) ||
+                (DL_STR_StrCmp((const DL_CHAR *)iTimestampStr,(const DL_CHAR *)kTIMESTAMP_MAX_VALUE,0) ==  1)) )
 	{
 		ok = 0;
 	}

--- a/lib/dl_time.c
+++ b/lib/dl_time.c
@@ -335,7 +335,7 @@ void DL_TIME_ConvUTCSecondsToLocalFormatStr ( DL_UINT32  iUtcSecs,
 	DL_TIME st;
 
 	/* init outputs */
-	sprintf(ioFormatStr,"");
+	ioFormatStr[0] = 0;
 
 	/* convert UTC seconds to Local structure */
 	DL_TIME_ConvUTCSecondsToLocalStruct(iUtcSecs,&st);

--- a/lib/org/dl_c_common_v0_0_2/dl_time.c
+++ b/lib/org/dl_c_common_v0_0_2/dl_time.c
@@ -689,7 +689,7 @@ static int timestamp_to_struct ( const char *iTimestampStr,
 	DL_MEM_memset(oData,0,sizeof(DL_TIME));
 
 	/* check 'timestamp' format (high-level) */
-	ok = DL_STR_Validate(iTimestampStr,kDL_TIME_TIMESTAMP_LEN,kDL_TIME_TIMESTAMP_LEN,"0123456789");
+	ok = DL_STR_Validate((const DL_CHAR *)iTimestampStr,kDL_TIME_TIMESTAMP_LEN,kDL_TIME_TIMESTAMP_LEN,(const DL_CHAR *)"0123456789");
 
 	/* check that date/time string is within the required range */
     if ( ok && ((DL_STR_StrCmp(iTimestampStr,kTIMESTAMP_MIN_VALUE,0) == -1) ||

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,8 @@
 {
   "name": "iso-8583",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "balanced-match": {
       "version": "1.0.0",
@@ -18,7 +19,11 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "browser-stdout": {
       "version": "1.3.0",
@@ -30,7 +35,10 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -42,7 +50,10 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
       "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ms": "0.7.2"
+      }
     },
     "diff": {
       "version": "3.2.0",
@@ -66,7 +77,15 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -90,7 +109,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -108,7 +131,11 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -138,7 +165,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -156,13 +188,21 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
     },
     "minimist": {
       "version": "0.0.8",
@@ -174,13 +214,29 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
     },
     "mocha": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
       "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.0",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      }
     },
     "ms": {
       "version": "0.7.2",
@@ -197,7 +253,10 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -209,7 +268,10 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
       "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has-flag": "1.0.0"
+      }
     },
     "wrappy": {
       "version": "1.0.2",


### PR DESCRIPTION
There is a number of warnings shown while compiling lib/ :

../lib/dl_str.c:48:34: warning: pointer targets in passing argument 1 of ‘getenv’ differ in signedness [**-Wpointer-sign**]
     return DL_STR_SafeStr(getenv(iEnvStr));

../lib/dl_str.c:209:44: warning: passing argument 2 of ‘DL_MEM_malloc’ from incompatible pointer type [**-Wincompatible-pointer-types**]
  else if ( err = DL_MEM_malloc(iMaxChars+1,oStr) )

../lib/dl_str.c:209:12: warning: suggest parentheses around assignment used as truth value [**-Wparentheses**]
  else if ( err = DL_MEM_malloc(iMaxChars+1,oStr) )

../lib/dl_time.c:338:22: warning: zero-length gnu_printf format string [**-Wformat-zero-length**]
  sprintf(ioFormatStr,"");

