### PR TITLE
Issue#7: fixed no member named 'to_string' in namespace 'std' error

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,6 +2,7 @@
     "targets": [
         {
             "target_name": "ISO8583",
+            "cflags_cc!": [ "-std=c++11" ],
             "sources": [ 
             	"NativeExtension.cc", "functions.cc", 
             	"lib/dl_iso8583.c",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iso-8583",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Packing and unpacking ISO 8583 messages",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
As std::to_string() has only appeared in C++11, _functions.cc_ won't compile without explicit _-std=c++11_ compiler option